### PR TITLE
fix: rename `setField` to `setRecord` in `VelocityGlobalRecords`

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/api_extender/velocity/VelocityGlobalRecords.java
+++ b/src/main/java/ch/sbb/polarion/extension/api_extender/velocity/VelocityGlobalRecords.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 @NoArgsConstructor
 public class VelocityGlobalRecords extends VelocityReadOnlyGlobalRecords {
 
-    public void setField(@NotNull String key, @NotNull String value) throws JAXBException, IOException {
+    public void setRecord(@NotNull String key, @NotNull String value) throws JAXBException, IOException {
         new GlobalRecords().setRecord(key, value);
     }
 }


### PR DESCRIPTION
### Proposed changes

This pull request makes a small change to the `VelocityGlobalRecords` class, renaming a method for clarity and consistency.

- Renamed the method `setField` to `setRecord` in the `VelocityGlobalRecords` class to better reflect its purpose and match naming conventions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
