### PR TITLE
chore: align web.xml with canonical formatting

### DIFF
--- a/src/main/resources/webapp/api-extender-admin/WEB-INF/web.xml
+++ b/src/main/resources/webapp/api-extender-admin/WEB-INF/web.xml
@@ -1,64 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-		 https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
-		 version="6.1">
-	<display-name>api-extender-admin</display-name>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+         version="6.1">
+    <display-name>api-extender-admin</display-name>
 
-	<filter>
-		<filter-name>DoAsFilter</filter-name>
-		<filter-class>com.polarion.portal.tomcat.servlets.DoAsFilter</filter-class>
-	</filter>
+    <filter>
+        <filter-name>DoAsFilter</filter-name>
+        <filter-class>com.polarion.portal.tomcat.servlets.DoAsFilter</filter-class>
+    </filter>
 
-	<filter-mapping>
-		<filter-name>DoAsFilter</filter-name>
-		<url-pattern>/*</url-pattern>
-	</filter-mapping>
+    <filter-mapping>
+        <filter-name>DoAsFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 
-	<servlet>
-		<servlet-name>api-extender-admin-ui</servlet-name>
-		<servlet-class>ch.sbb.polarion.extension.api_extender.ApiExtenderAdminUiServlet</servlet-class>
+    <servlet>
+        <servlet-name>api-extender-admin-ui</servlet-name>
+        <servlet-class>ch.sbb.polarion.extension.api_extender.ApiExtenderAdminUiServlet</servlet-class>
 
-		<init-param>
-			<param-name>debug</param-name>
-			<param-value>0</param-value>
-		</init-param>
-		<load-on-startup>1</load-on-startup>
-	</servlet>
+        <init-param>
+            <param-name>debug</param-name>
+            <param-value>0</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
 
-	<servlet-mapping>
-		<servlet-name>api-extender-admin-ui</servlet-name>
-		<url-pattern>/ui/*</url-pattern>
-	</servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>api-extender-admin-ui</servlet-name>
+        <url-pattern>/ui/*</url-pattern>
+    </servlet-mapping>
 
-	<session-config>
-		<session-timeout>30</session-timeout>
-	</session-config>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
 
-	<mime-mapping>
-		<extension>log</extension>
-		<mime-type>text/plain</mime-type>
-	</mime-mapping>
+    <mime-mapping>
+        <extension>log</extension>
+        <mime-type>text/plain</mime-type>
+    </mime-mapping>
 
-	<security-constraint>
-		<web-resource-collection>
-			<web-resource-name>All</web-resource-name>
-			<url-pattern>/*</url-pattern>
-		</web-resource-collection>
-		<auth-constraint>
-			<role-name>user</role-name>
-		</auth-constraint>
-	</security-constraint>
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>All</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>user</role-name>
+        </auth-constraint>
+    </security-constraint>
 
-	<!-- Login configuration uses form-based authentication -->
-	<login-config>
-		<auth-method>FORM</auth-method>
-		<realm-name>PolarionRealm</realm-name>
-		<form-login-config>
-			<form-login-page>/login/login</form-login-page>
-			<form-error-page>/login/error</form-error-page>
-		</form-login-config>
-	</login-config>
+    <!-- Login configuration uses form-based authentication -->
+    <login-config>
+        <auth-method>FORM</auth-method>
+        <realm-name>PolarionRealm</realm-name>
+        <form-login-config>
+            <form-login-page>/login/login</form-login-page>
+            <form-error-page>/login/error</form-error-page>
+        </form-login-config>
+    </login-config>
 </web-app>

--- a/src/main/resources/webapp/api-extender/WEB-INF/web.xml
+++ b/src/main/resources/webapp/api-extender/WEB-INF/web.xml
@@ -1,86 +1,85 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-		 https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
-		 version="6.1">
-	<display-name>api-extender</display-name>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+         version="6.1">
+    <display-name>api-extender</display-name>
 
-	<listener>
-		<listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
-	</listener>
+    <listener>
+        <listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
+    </listener>
 
-	<filter>
-		<filter-name>DoAsFilter</filter-name>
-		<filter-class>com.polarion.portal.tomcat.servlets.DoAsFilter</filter-class>
-	</filter>
+    <filter>
+        <filter-name>DoAsFilter</filter-name>
+        <filter-class>com.polarion.portal.tomcat.servlets.DoAsFilter</filter-class>
+    </filter>
 
-	<filter-mapping>
-		<filter-name>DoAsFilter</filter-name>
-		<url-pattern>/*</url-pattern>
-	</filter-mapping>
+    <filter-mapping>
+        <filter-name>DoAsFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 
-	<servlet>
-		<servlet-name>api-extender-rest</servlet-name>
-		<servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+    <servlet>
+        <servlet-name>api-extender-rest</servlet-name>
+        <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
 
-		<init-param>
-			<param-name>jakarta.ws.rs.Application</param-name>
-			<param-value>ch.sbb.polarion.extension.api_extender.rest.ApiExtenderRestApplication</param-value>
-		</init-param>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>ch.sbb.polarion.extension.api_extender.rest.ApiExtenderRestApplication</param-value>
+        </init-param>
 
         <init-param>
             <param-name>jersey.config.server.provider.classnames</param-name>
             <param-value>org.glassfish.jersey.media.multipart.MultiPartFeature</param-value>
         </init-param>
 
-		<init-param>
-			<param-name>debug</param-name>
-			<param-value>0</param-value>
-		</init-param>
-		<load-on-startup>1</load-on-startup>
-	</servlet>
+        <init-param>
+            <param-name>debug</param-name>
+            <param-value>0</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
 
-	<servlet-mapping>
-		<servlet-name>api-extender-rest</servlet-name>
-		<url-pattern>/rest/*</url-pattern>
-	</servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>api-extender-rest</servlet-name>
+        <url-pattern>/rest/*</url-pattern>
+    </servlet-mapping>
 
-	<session-config>
-		<session-timeout>30</session-timeout>
-	</session-config>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
 
-	<mime-mapping>
-		<extension>log</extension>
-		<mime-type>text/plain</mime-type>
-	</mime-mapping>
+    <mime-mapping>
+        <extension>log</extension>
+        <mime-type>text/plain</mime-type>
+    </mime-mapping>
 
-	<security-constraint>
-		<web-resource-collection>
-			<web-resource-name>All</web-resource-name>
-			<url-pattern>/*</url-pattern>
-		</web-resource-collection>
-		<auth-constraint>
-			<role-name>user</role-name>
-		</auth-constraint>
-	</security-constraint>
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>All</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>user</role-name>
+        </auth-constraint>
+    </security-constraint>
 
-	<security-constraint>
-		<web-resource-collection>
-			<web-resource-name>All</web-resource-name>
-			<url-pattern>/rest/api/*</url-pattern>
-		</web-resource-collection>
-		<auth-constraint/>
-	</security-constraint>
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>All</web-resource-name>
+            <url-pattern>/rest/api/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint/>
+    </security-constraint>
 
-	<!-- Login configuration uses form-based authentication -->
-	<login-config>
-		<auth-method>FORM</auth-method>
-		<realm-name>PolarionRealm</realm-name>
-		<form-login-config>
-			<form-login-page>/login/login</form-login-page>
-			<form-error-page>/login/error</form-error-page>
-		</form-login-config>
-	</login-config>
+    <!-- Login configuration uses form-based authentication -->
+    <login-config>
+        <auth-method>FORM</auth-method>
+        <realm-name>PolarionRealm</realm-name>
+        <form-login-config>
+            <form-login-page>/login/login</form-login-page>
+            <form-error-page>/login/error</form-error-page>
+        </form-login-config>
+    </login-config>
 </web-app>


### PR DESCRIPTION
Standardizes every `web.xml` descriptor on the canonical `aad-synchronizer`
formatting so all extensions share an identical header and indentation style.

### Changes
- `web-app` header attribute order: `xmlns` before `xmlns:xsi`, with the
  `schemaLocation` continuation aligned under the namespace URI (the Siemens
  2606 canonical header)
- 4-space indentation, no tabs
- no blank line between the header and the first body element

Formatting only -- no functional change. The Jakarta schema
(`web-app_6_1.xsd`, `version="6.1"`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
