### PR TITLE
chore: sync CI/docs drift from open-source-polarion-java-repo-template

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@
 name: Claude Code Review
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened]
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@
 name: CodeQL
 on:
   push:
-    branches: [main]
+    branches: [main, release-v*]
   pull_request:
-    branches: [main]
+    branches: [main, release-v*]
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # Weekly, off-peak Sunday — matches the cadence default setup uses.

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     outputs:
       project_version: ${{ steps.project_metadata.outputs.version }}
       is_release: ${{ steps.project_metadata.outputs.is_release }}
@@ -107,7 +106,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     env:
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME }}
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN }}
@@ -139,18 +137,59 @@ jobs:
             -Dmaven.wagon.http.connectionTimeout=3600000 \
             -Dmaven.wagon.http.readTimeout=3600000 \
             -Dcentral-publishing-maven-plugin.autoPublish=${{ github.event.repository.visibility == 'public' }}
-  # Deploy to GitHub Packages (snapshots from main only) and upload release assets to GitHub Release
-  # LTS branches (release-v*) only upload release assets, no snapshot deployment
-  deploy-github-packages:
+  # Publish to JFrog Artifactory (sbb.jfrog.io/artifactory/polarion-mvn).
+  # SNAPSHOTs from main always; releases only when the repo is private (public
+  # releases go to Maven Central, see deploy-maven-central). Reuses the artifact
+  # built by the build job via deploy:deploy-file (no rebuild).
+  deploy-jfrog-io:
     needs: build
     if: ${{ github.ref == 'refs/heads/main' || (needs.build.outputs.is_release == 'true' && startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+    env:
+      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
+      PROJECT_VERSION: ${{ needs.build.outputs.project_version }}
+    steps:
+      - name: 📄 Checkout the repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: 📥 Download build artifacts
+        # The artifacts are generated in the 'build' job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: maven-artifacts
+          path: target/
+      - name: 🧱 Set up JDK and Maven
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5.3.0
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+      - name: 📦 Deploy to JFrog Artifactory
+        # SNAPSHOTs always; releases only when the repo is private (public releases
+        # go to Maven Central). Main JAR + POM only — sources/javadoc are produced
+        # only for Maven Central releases.
+        if: ${{ needs.build.outputs.is_release == 'false' || github.event.repository.visibility == 'private' }}
+        run: |
+          jar=(target/*-"${PROJECT_VERSION}".jar)
+          mvn --batch-mode -s "${SETTINGS_XML}" deploy:deploy-file \
+            -DrepositoryId=jfrog_io \
+            -Durl=https://sbb.jfrog.io/artifactory/polarion-mvn \
+            -DpomFile=pom.xml \
+            -Dfile="${jar[0]}"
+  # Attach the built JAR to the GitHub Release page. Releases are published to Maven
+  # Central (public repos) or JFrog Artifactory (private repos); SNAPSHOTs go to JFrog.
+  upload-release-assets:
+    needs: build
+    if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
+    runs-on: ubuntu-latest
+    permissions:
       contents: write
-      packages: write
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      GITHUB_REPO_NAME: ${{ github.repository }}
       PROJECT_VERSION: ${{ needs.build.outputs.project_version }}
     steps:
       - name: 📄 Checkout the repository
@@ -164,23 +203,6 @@ jobs:
         with:
           name: maven-artifacts
           path: target/
-      - name: 🧱 Set up JDK and Maven
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5.3.0
-        with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: 📦 Deploy to GitHub Packages
-        # Releases should only be deployed to GitHub Packages when the repo is private
-        # Snapshots are always deployed to GitHub Packages
-        if: ${{ needs.build.outputs.is_release == 'false' || github.event.repository.visibility == 'private' }}
-        run: |
-          mvn --batch-mode -s "${SETTINGS_XML}" deploy \
-            -Dmaven.test.skip=true \
-            -Dmaven.javadoc.skip=true \
-            -Dmaven.source.skip=true \
-            -P deploy-github-packages
       - name: 📦 Upload assets to GitHub Release
-        if: ${{ needs.build.outputs.is_release == 'true' }}
         run: |-
           gh release upload "v${PROJECT_VERSION}" "target/*-${PROJECT_VERSION}.jar" --clobber

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -3,6 +3,11 @@ name: release-please-guard
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Runs on Renovate automerge branches so the required "release-please-guard"
+  # check exists on the commit Renovate fast-forwards onto the default branch
+  # (branch automerge pushes directly with no PR).
+  push:
+    branches: [renovate/**]
 permissions: {}
 jobs:
   release-please-guard:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Gotchas
 
 - **`ch.sbb.polarion.extension.generic`** is the parent project providing reusable infrastructure for all Polarion plugins in this org (settings framework, REST base classes, OSGi helpers, etc.). Before implementing anything cross-cutting, check if it already exists there.
-- **Maven Settings**: Builds require `.mvn/settings.xml` (JFrog, GitHub Packages, Sonatype credentials via env vars). CI passes it with `-s .mvn/settings.xml`. `.mvn/maven.config` auto-activates the Polarion version profile.
+- **Maven Settings**: Builds require `.mvn/settings.xml` (JFrog Artifactory, Sonatype credentials via env vars). CI passes it with `-s .mvn/settings.xml`. `.mvn/maven.config` auto-activates the Polarion version profile.
 - **Polarion Dependencies**: You must extract dependencies from the Polarion installer using [polarion-artifacts-deployer](https://github.com/SchweizerischeBundesbahnen/polarion-artifacts-deployer) before the Maven build will work.
 - **Local Polarion Installation**: Requires `POLARION_HOME` environment variable. Use the `install-to-local-polarion` Maven profile: `mvn clean install -P install-to-local-polarion`
 - **After any code change**: Delete `<POLARION_HOME>/data/workspace/.config` before restarting Polarion or changes won't be picked up.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,15 +53,17 @@ The `release-v*` pattern in the workflow automatically recognizes new LTS branch
 
 ### Deployment Matrix
 
-| Branch | Version Type | Maven Central | GitHub Packages | GitHub Release |
-|--------|--------------|---------------|-----------------|----------------|
+| Branch | Version Type | Maven Central | JFrog Artifactory | GitHub Release |
+|--------|--------------|---------------|-------------------|----------------|
 | `main` | SNAPSHOT | - | ✓ | - |
-| `main` | Release | ✓ | - | ✓ |
+| `main` | Release | ✓ (public) | ✓ (private only) | ✓ |
 | `release-v*` | SNAPSHOT | - | - | - |
-| `release-v*` | Release | ✓ | - | ✓ |
+| `release-v*` | Release | ✓ (public) | ✓ (private only) | ✓ |
 
 ### Notes
 
-- SNAPSHOT versions from LTS branches are NOT deployed to GitHub Packages
+- SNAPSHOTs are published to JFrog Artifactory (`sbb.jfrog.io/artifactory/polarion-mvn`); publishing to GitHub Packages was removed
+- Releases go to Maven Central for public repositories, or to JFrog Artifactory for private repositories
+- SNAPSHOT versions from LTS branches are NOT deployed anywhere
 - Only release versions from LTS branches are deployed to Maven Central
 - Each LTS branch operates independently with its own release PR


### PR DESCRIPTION
Syncs this repo against `open-source-polarion-java-repo-template`@`aaad318` (2026-06-28).

Six sync-eligible files had drifted; each change traces to a merged template PR.

## Workflows (`ci:`)
| File | Change | Source |
|------|--------|--------|
| `maven-build.yml` | Stop publishing to GitHub Packages; publish SNAPSHOTs (and private-repo releases) to JFrog Artifactory (`sbb.jfrog.io/artifactory/polarion-mvn`) via `deploy:deploy-file`; split GitHub Release asset upload into its own `upload-release-assets` job; drop `packages:` permissions | template [#162](https://github.com/SchweizerischeBundesbahnen/open-source-polarion-java-repo-template/pull/162) |
| `release-please-guard.yml` | Run guard on `push` to `renovate/**` branches so the required `release-please-guard` check exists on Renovate branch-automerge commits | template [#161](https://github.com/SchweizerischeBundesbahnen/open-source-polarion-java-repo-template/pull/161) |
| `codeql.yml` | Run CodeQL on `release-v*` push/PR branches | template [#156](https://github.com/SchweizerischeBundesbahnen/open-source-polarion-java-repo-template/pull/156) |
| `claude-code-review.yml` | Remove `synchronize` from PR trigger types | template [#154](https://github.com/SchweizerischeBundesbahnen/open-source-polarion-java-repo-template/pull/154) |

## Docs (`docs:`)
| File | Change | Source |
|------|--------|--------|
| `RELEASE.md` | Deployment matrix + notes updated for JFrog (GitHub Packages removed) | template [#162](https://github.com/SchweizerischeBundesbahnen/open-source-polarion-java-repo-template/pull/162) |
| `CLAUDE.md` | Maven Settings note: drop "GitHub Packages" from credentials list (hand-merged) | template [#162](https://github.com/SchweizerischeBundesbahnen/open-source-polarion-java-repo-template/pull/162) |

## Notes
- The previously-uncommitted local `release-please-guard.yml` edit (the same `renovate/**` push trigger) is superseded by the template's canonical version in this sync — no divergence remains.
- **Conditional gates (no change):** `openapi-validation.yml` + `redocly.yaml` kept (repo has `docs/openapi.json`); CodeQL advanced setup already active.
- **No action-pin bumps** ride in this sync (those remain Renovate's job).

## Repo-settings follow-up
- [ ] `maven-build.yml` now reads `secrets.IO_JFROG_SBB_POLARION_TOKEN` — confirm the secret is available to this repo (org-level for template #162) before the next deploy.

Closes #131