### PR TITLE
docs: regenerate the OpenAPI spec for generic 15.10.1

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -340,7 +340,7 @@
     },
     "/api/roles": {
       "get": {
-        "operationId": "getRoles_1",
+        "operationId": "getRoles",
         "parameters": [
           {
             "description": "Scope, e.g. project/<projectId>/ (empty for global scope)",
@@ -734,37 +734,6 @@
         "summary": "Returns version of Polarion's extension",
         "tags": [
           "Extension Information"
-        ]
-      }
-    },
-    "/internal/roles": {
-      "get": {
-        "operationId": "getRoles",
-        "parameters": [
-          {
-            "description": "Scope, e.g. project/<projectId>/ (empty for global scope)",
-            "in": "query",
-            "name": "scope",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RolesInfo"
-                }
-              }
-            },
-            "description": "Successfully retrieved the available roles"
-          }
-        },
-        "summary": "Get the global and project roles available in the specified scope",
-        "tags": [
-          "Roles"
         ]
       }
     }


### PR DESCRIPTION
### Proposed changes

`docs/openapi.json` is generated at build time, and it had drifted from what the build now produces: generic 15.10.1 marks `RolesInternalController` `@Hidden`, so `/internal/roles` is no longer published — and with it gone the public endpoint loses the disambiguating suffix swagger had added, `getRoles_1` becoming `getRoles`.

Nothing about the served API changes: `/internal/*` endpoints are session-authenticated and exist for this extension's own UI, never part of the documented surface. This is the swagger plugin's own output after `mvn package`, not a hand edit.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
