### PR TITLE
ci: adopt reusable Polarion Semgrep workflow as non-blocking check

### DIFF
--- a/.github/workflows/polarion-semgrep.yml
+++ b/.github/workflows/polarion-semgrep.yml
@@ -12,13 +12,8 @@ on:
 permissions: {}
 jobs:
   semgrep:
-    # Pinned at the feature branch until
-    # SchweizerischeBundesbahnen/github-workflows-polarion#95 merges, so that the
-    # first Code Scanning run happens before that pull request lands rather than
-    # after it. Both refs move to @main once it is merged.
-    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-polarion-semgrep.yml@feat/reusable-polarion-semgrep
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-polarion-semgrep.yml@main
     permissions:
       contents: read
       security-events: write
-    with:
-      rules-ref: feat/reusable-polarion-semgrep
+      actions: read

--- a/.github/workflows/polarion-semgrep.yml
+++ b/.github/workflows/polarion-semgrep.yml
@@ -1,0 +1,24 @@
+---
+name: Polarion Semgrep
+on:
+  push:
+    branches: [main, release-v*]
+  pull_request:
+    branches: [main, release-v*]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Weekly, off-peak Sunday — twenty minutes after the CodeQL run.
+    - cron: 37 5 * * 0
+permissions: {}
+jobs:
+  semgrep:
+    # Pinned at the feature branch until
+    # SchweizerischeBundesbahnen/github-workflows-polarion#95 merges, so that the
+    # first Code Scanning run happens before that pull request lands rather than
+    # after it. Both refs move to @main once it is merged.
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-polarion-semgrep.yml@feat/reusable-polarion-semgrep
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      rules-ref: feat/reusable-polarion-semgrep


### PR DESCRIPTION
First consumer adoption of the reusable Polarion Semgrep workflow. Implements #115.

## Ref

`uses:` points at `@main`. SchweizerischeBundesbahnen/github-workflows-polarion#95 is merged, so `reusable-polarion-semgrep.yml` exists on the default branch and the ref resolves. The `rules-ref` input this pull request originally passed no longer exists: SchweizerischeBundesbahnen/github-workflows-polarion#100 replaced it, and the reusable workflow now checks out its own source at `job.workflow_sha`, so the `uses:` ref alone decides both the workflow and the rule-pack content.

Until release-please SchweizerischeBundesbahnen/github-workflows-polarion#29 merges there is no tag, so `@main` is the only ref available. Pinning to a tag is a follow-up.

## Expected result

Simulated locally with the exact invocation the reusable workflow uses, against this repository at `main` (`6d7f5a7`), semgrep 1.172.0, Polarion rules only:

- **1 finding** — `polarion-transaction-no-permission-check` at INFO, on `src/main/java/ch/sbb/polarion/extension/api_extender/project/GenericFields.java`.

The remaining seven rules fire nowhere here. If the run reports anything other than one INFO finding, the reusable workflow is at fault rather than this wrapper.

## Non-blocking on purpose

The check is not proposed as required. Seven of the eight rules produce no findings on the current extension corpus and the eighth is INFO severity, so there is nothing to block today; the pack's value is as a regression guard on new code. Promotion to a required check is a separate decision, and it belongs after a rule has actually caught something.

## Interaction with the existing scanners

The reusable workflow runs the Polarion rules only — no `p/java`, no `p/owasp-top-ten` — because CodeQL `security-extended` and SonarCloud already cover generic Java and OWASP here. Alerts arrive under their own Code Scanning category, `polarion-semgrep`, so they do not mix with the CodeQL ones.

Refs #115, SchweizerischeBundesbahnen/github-workflows-polarion#76
